### PR TITLE
Fix next app router support

### DIFF
--- a/packages/react/src/LazyVideo/LazyVideoServer.tsx
+++ b/packages/react/src/LazyVideo/LazyVideoServer.tsx
@@ -1,0 +1,55 @@
+import type { ReactElement } from 'react'
+import type { LazyVideoProps } from '../types/lazyVideoTypes'
+import LazyVideoClient from './LazyVideoClient'
+
+// This wrapper function exists to take Function props and make them
+// serializable for the LazyVideoClient component, which is a Next.js style
+// client component.
+export default function LazyVideo(
+  props: LazyVideoProps
+): ReactElement | undefined {
+
+  // Destructure some props
+  const {
+    src,
+    sourceMedia,
+    videoLoader,
+  } = props
+
+  // Multiple media queries and a loader func are necessary for responsive
+  const useResponsiveSource = sourceMedia
+    && sourceMedia?.length > 1
+    && !!videoLoader
+
+  // Vars that will be conditionally populated
+  let srcUrl, mediaSrcs
+
+  // Prepare a hash of source URLs and their media query constraint in the
+  // style expected by useMediaQueries.
+  if (useResponsiveSource) {
+    const mediaSrcEntries = sourceMedia.map(media => {
+      const url = videoLoader({ src, media })
+      return [url, media]
+    })
+    // If the array ended up empty, abort
+    if (mediaSrcEntries.filter(([url]) => !!url).length == 0) return
+
+    // Make the hash
+    mediaSrcs = Object.fromEntries(mediaSrcEntries)
+
+  // Make a simple string src url
+  } else {
+    if (videoLoader) srcUrl = videoLoader({ src })
+    else if (typeof src == 'string') srcUrl = src
+    if (!srcUrl) return // If no url could be built, abort
+  }
+
+  // Render client component
+  return (
+    <LazyVideoClient
+      {...props}
+      {...{ srcUrl, mediaSrcs }}
+    />
+  )
+}
+

--- a/packages/react/src/LazyVideo/LazyVideoServer.tsx
+++ b/packages/react/src/LazyVideo/LazyVideoServer.tsx
@@ -46,9 +46,18 @@ export default function LazyVideo(
 
   // Render client component
   return (
-    <LazyVideoClient
-      {...props}
-      {...{ srcUrl, mediaSrcs }}
+    <LazyVideoClient {...{
+        ...props,
+
+        // Remove client-unfriendly props
+        videoLoader: undefined,
+        src: undefined,
+        sourceMedia: undefined,
+
+        // Add client-friendly props
+        srcUrl,
+        mediaSrcs,
+      }}
     />
   )
 }

--- a/packages/react/src/LazyVideo/index.ts
+++ b/packages/react/src/LazyVideo/index.ts
@@ -1,0 +1,3 @@
+// Export the server component as the defalut LazyVideo component
+import LazyVideoServer from './LazyVideoServer'
+export default LazyVideoServer

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,5 @@
 import ReactVisual from './ReactVisual'
-import LazyVideo from './LazyVideo'
+import LazyVideo from './LazyVideo/LazyVideoServer'
 import VisualWrapper from './VisualWrapper'
 import { collectDataAttributes } from './lib/attributes'
 


### PR DESCRIPTION
Fixes this error:

```
Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server".
  <... src={{...}} alt=... fit="cover" position=... priority=... noPoster=... paused=... sourceMedia=... videoLoader={function}>
```