### PR TITLE
Switch to ES6 exports

### DIFF
--- a/packages/contentful/package.json
+++ b/packages/contentful/package.json
@@ -4,6 +4,7 @@
   "description": "Image and video renderer for Contentful assets.",
   "author": "Bukwild <info@bukwild.com>",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/next/next.config.js
+++ b/packages/next/next.config.js
@@ -1,5 +1,5 @@
 // Configuration of next/image for Cypress tess
-module.exports = {
+export default {
   images: {
 
     // Disable Next.js producing it's own crops within dev server which don't

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -4,6 +4,7 @@
   "description": "Image and video renderer for Next.js projects",
   "author": "Bukwild <info@bukwild.com>",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/next/src/NextVisual.tsx
+++ b/packages/next/src/NextVisual.tsx
@@ -1,4 +1,8 @@
-import Image from 'next/image'
+// `next/image` as importing as { default: Image, __esmodule: true } when
+// this file was loaded by @react-visual/sanity-next. This is my hack to fix
+import _Image from "next/image";
+const Image = ("default" in _Image ? _Image.default : _Image) as typeof _Image;
+
 import type { ReactElement } from 'react'
 
 import { makeImagePlaceholder } from './lib/placeholder'

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,6 +4,7 @@
   "description": "Image and video renderer for React projects",
   "author": "Bukwild <info@bukwild.com>",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/sanity-next/next.config.js
+++ b/packages/sanity-next/next.config.js
@@ -1,5 +1,5 @@
 // Configuration of next/image for Cypress tess
-module.exports = {
+export default {
   images: {
 
     // Support tests fetching imaages from placehold.co

--- a/packages/sanity-next/package.json
+++ b/packages/sanity-next/package.json
@@ -4,6 +4,7 @@
   "description": "Image and video renderer for Sanity + Next.js projects",
   "author": "Bukwild <info@bukwild.com>",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
+    "target": "ESNext",
+    "module": "ESNext",
     "declaration": true,
     "outDir": "./dist",
     "strict": true,
@@ -9,6 +9,10 @@
 
     // Required for importing packages, like React, that have `export =`
     "esModuleInterop": true,
+
+    // Recommendations for greater interoperability
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
 
     // Fixes build failures when dependent types have errors, like:
     // node_modules/next/dist/shared/lib/get-img-props.d.ts:70

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "es2022",
+    "module": "es2022",
     "declaration": true,
     "outDir": "./dist",
     "strict": true,


### PR DESCRIPTION
So Vite doesn't complain like:

> Uncaught SyntaxError: The requested module '/node_modules/@react-visual/contentful/dist/index.js?v=63b79c2f' does not provide an export named 'default' (at RichText.tsx:4:8)

Got this idea from:

- https://github.com/vitejs/vite/issues/11783#issuecomment-1432060571
- https://chatgpt.com/share/1e262976-7d1a-4636-b75a-5f8676a49f47