### PR TITLE
Remove width/height from fillStyles

### DIFF
--- a/packages/react/src/lib/styles.ts
+++ b/packages/react/src/lib/styles.ts
@@ -3,8 +3,6 @@ import type { CSSProperties } from 'react'
 // Mimic the styles that next/image sets when `fill` prop is applied
 export const fillStyles = {
   position: 'absolute',
-  height: '100%',
-  width: '100%',
   inset: '0px',
 } as CSSProperties
 


### PR DESCRIPTION
When combined with a forced `relative` on the parent, it can cause the visual to expand outside of container