### PR TITLE
Fix ADA pause control

### DIFF
--- a/packages/react/src/LazyVideo/LazyVideoClient.tsx
+++ b/packages/react/src/LazyVideo/LazyVideoClient.tsx
@@ -103,12 +103,12 @@ export default function LazyVideoClient({
 
     const handlePlay = () => {
       setVideoPaused(false);
-      onPlay && onPlay();
+      onPlay?.();
     };
 
     const handlePause = () => {
       setVideoPaused(true);
-      onPause && onPause();
+      onPause?.();
     };
 
     // Add listeners

--- a/packages/react/src/LazyVideo/LazyVideoClient.tsx
+++ b/packages/react/src/LazyVideo/LazyVideoClient.tsx
@@ -77,11 +77,7 @@ export default function LazyVideoClient({
   // errors while trying to play.
   const play = async () => {
     if (playPromise.current) await playPromise.current;
-    try {
-      playPromise.current = videoRef.current?.play();
-    } catch (e) {
-      console.error(e);
-    }
+    playPromise.current = videoRef.current?.play().catch((e) => {});
   };
 
   // Pause the video, waiting until it's safe to play it


### PR DESCRIPTION
This was an issue with responsive video sources.  They would immediately cause a load before the play finished.